### PR TITLE
Improve regexp to match also with DOID

### DIFF
--- a/httpproxy/test_utils.py
+++ b/httpproxy/test_utils.py
@@ -1,0 +1,9 @@
+
+from httpproxy.utils import encode_partial_urls
+
+def test_encode_partial_urls():
+    assert '/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2FC0460402/children' \
+        == encode_partial_urls('/ontologies/SNOMEDCT/classes/http%3A//purl.bioontology.org/ontology/SNOMEDCT/C0460402/children'), 'SNOMED ontologytree'
+
+    assert '/ontologies/DOID/classes/http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FDOID_4/children' \
+        == encode_partial_urls('/ontologies/DOID/classes/http%3A//purl.obolibrary.org%2Fobo%2FDOID_4/children'), 'DOID_4 ontologytree'

--- a/httpproxy/utils.py
+++ b/httpproxy/utils.py
@@ -1,13 +1,13 @@
 import re
 from django.utils.http import urlquote_plus, urlunquote
 
-def encode_partial_urls(url, key='(?s)(http).*(\d{4}?)'):
+def encode_partial_urls(url, key='(?s)(http).*(?=((\\/).*))'):
     """
     Encodes url, especially for the ontologyserver
     From:
-        ontologies/SNOMEDCT/classes/http://purl.bioontology.org/ontology/SNOME
+        /ontologies/SNOMEDCT/classes/http%3A//purl.bioontology.org/ontology/SNOMEDCT/C0460402/children
     To:
-        ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOME
+        '/ontologies/SNOMEDCT/classes/http%3A%2F%2Fpurl.bioontology.org%2Fontology%2FSNOMEDCT%2FC0460402/children
     @param url <string>
     @param key <regexp>
     @return <string>
@@ -16,10 +16,9 @@ def encode_partial_urls(url, key='(?s)(http).*(\d{4}?)'):
     # take the clean parts of the URL
     tmp = re.split(key, url)
     (start, end) = (tmp[0], tmp[-1])
-
     # find the url to be encoded and unquote it:
-    payload = urlunquote(re.search(key, url).group(0))
 
+    payload = urlunquote(re.search(key, url).group(0))
     # encode the string
     encoded_string = urlquote_plus(payload)
 


### PR DESCRIPTION
Old regex did not match to doid-style urls, which caused service to fail.